### PR TITLE
Added Deletion steps in the before block to start testing using a fresh account

### DIFF
--- a/api/api-client.js
+++ b/api/api-client.js
@@ -76,11 +76,6 @@ function extractContactIdsFromResponse(responseArray) {
     return contactIdList;
 }
 
-
-
-
-
-
 export async function deleteContactThroughAPI({userId, token}) {
     const config = {
         headers: { 
@@ -99,11 +94,6 @@ export async function deleteContactThroughAPI({userId, token}) {
     if(deleteResponse.status == 200 )
         return true;
 };
-
-
-
-
-
 
 export async function deleteAllContactsThroughAPI({token}) {
     const config ={

--- a/api/api-client.js
+++ b/api/api-client.js
@@ -36,13 +36,89 @@ export async function createContactThroughAPI({firstName, lastName, email, phone
 
     let contactResponse = await axios.post(baseUrl + 'api/contacts', data, config)
     .then( function(response) {
-        console.log("Create Contact Successful: ")
         return response;
     })
     .catch( async function (error) {
         console.log("Error in creating contact: " + error);
     });    
 
-    // if(contactResponse.status == 201)
-        console.log(contactResponse.data.firstName + ' ' + contactResponse.data.lastName);
+    if(contactResponse.status == 201)
+        console.log('Contact Created: ' + contactResponse.data.firstName + ' ' + contactResponse.data.lastName);
+}
+
+export async function getAllCustomersThroughAPI({token}) {
+    
+    const config ={
+        headers: { 
+            Authorization: `Bearer ${token}`
+        }
+    }
+
+    let contactResponse = await axios.get(baseUrl + 'api/contacts', config)
+    .then( function(response) {
+        return response;
+    })
+    .catch( async function (error) {
+        console.log("Error in fetch all contacts: " + error);
+    });    
+
+    if(contactResponse.status == 200)
+        console.log("Get All Contacts successful");
+    return contactResponse;
+}
+ 
+function extractContactIdsFromResponse(responseArray) {
+    let contactIdList = [];
+    
+    for (let i = 0; i < responseArray.length; i++) 
+        contactIdList[i] = responseArray[i].id;
+
+    return contactIdList;
+}
+
+
+
+
+
+
+export async function deleteContactThroughAPI({userId, token}) {
+    const config = {
+        headers: { 
+            Authorization: `Bearer ${token}`
+        }
+    }  
+
+    let deleteResponse = await axios.delete(baseUrl + 'api/contacts/' + userId, config) 
+    .then( function(response) {
+        return response;
+    })
+    .catch( async function (error) {
+        console.log("Error encountered while logging in: " + error);
+    });
+
+    if(deleteResponse.status == 200 )
+        return true;
+};
+
+
+
+
+
+
+export async function deleteAllContactsThroughAPI({token}) {
+    const config ={
+        headers: { 
+            Authorization: `Bearer ${token}`
+        }
+    }  
+    
+    const allContactsList = await getAllCustomersThroughAPI({token});
+    const contactIdList = extractContactIdsFromResponse(allContactsList.data.docs);
+
+    let deletedContacts = [];
+    for (let i = 0; i < contactIdList.length; i++)
+        deletedContacts[i] = await deleteContactThroughAPI({userId: contactIdList[i], token: token});
+
+    if(deletedContacts.length == contactIdList.length) 
+        console.log("All contacts deleted.");
 }

--- a/test/pageobjects/contacts.page.js
+++ b/test/pageobjects/contacts.page.js
@@ -60,6 +60,18 @@ class ContactsPage extends Page {
         return $('//button[@nztooltiptitle="Log out"]');
     }
 
+    get contact1CardSettingsButton() {
+        return $('(//*[name()="svg" and @data-icon="setting"])[1]');
+    }
+    
+    get contactCardSettingsDeleteDropdown() {
+        return $('//div[contains(@id, "cdk-overlay-")]/div/div/ul/li[contains(text(), "Delete")]');
+    }
+
+    get contact1CardDeleteLoadingIcon() {
+        return $('.anticon-loading');
+    }
+
     async createContact(firstName, lastName, phone, email) {
 
         await this.waitAndClick(this.newContactButton);
@@ -75,6 +87,13 @@ class ContactsPage extends Page {
         await this.waitAndClick(this.saveContactsButtonDesktop);
 
         await this.waitForCreateContactFlashMessageToAppear();
+    }
+
+    async deleteFirstContact() {
+        await this.waitAndClick(this.contact1CardSettingsButton);
+        await this.waitAndClick(this.contactCardSettingsDeleteDropdown);
+
+        console.log("Contact deletion successful")
     }
 
     async logOutOfTestApp() {

--- a/test/pageobjects/contacts.page.js
+++ b/test/pageobjects/contacts.page.js
@@ -93,7 +93,18 @@ class ContactsPage extends Page {
         await this.waitAndClick(this.contact1CardSettingsButton);
         await this.waitAndClick(this.contactCardSettingsDeleteDropdown);
 
-        console.log("Contact deletion successful")
+        // console.log("Contact deletion successful")
+    }
+
+    async deleteAllContacts() {
+        let isExisting = true;
+        
+        while (isExisting) {
+            isExisting = await this.contact1CardSettingsButton.isExisting();
+            if(isExisting)
+                await this.deleteFirstContact();
+        }
+        console.log("All contacts deleted.");
     }
 
     async logOutOfTestApp() {

--- a/test/pageobjects/page.js
+++ b/test/pageobjects/page.js
@@ -13,7 +13,7 @@ export default class Page {
     }
 
     async waitAndClick(element) {
-        await element.waitForClickable({timeout: 20000});
+        await element.waitForClickable({timeout: 25000});
         await element.click();
         return true;
     }

--- a/test/specs/ui-api-test.js
+++ b/test/specs/ui-api-test.js
@@ -1,6 +1,7 @@
 import ContactsPage from '../pageobjects/contacts.page.js';
 import * as APIClient from '../../api/api-client.js'
 import LoginPage from '../pageobjects/login.page.js'
+import { expect as chaiExpect} from 'chai';
 
 let authToken = {};
 
@@ -10,8 +11,12 @@ describe('Fetch Contacts UI Tests with APIs - ', () => {
         await LoginPage.open();
 
         //Login to the test app
-        
         authToken = await APIClient.loginThroughAPI({email: 'ihsaan@addressbooktest.com', password: 'pass12345'});
+
+        //Fetch all the present contacts and delete them
+        await APIClient.deleteAllContactsThroughAPI({token: authToken.token});
+
+        //Create 3 new contacts
         await APIClient.createContactThroughAPI({firstName: 'Lionel', lastName: 'Messi', email: ['messi@psg.com'], phone: ['832732459723'], token: authToken.token});
         await APIClient.createContactThroughAPI({firstName: 'Cristiano', lastName: 'Ronaldo', email: ['ronaldo@alnassrfc.com'], phone: ['9829348534'], token: authToken.token});
         await APIClient.createContactThroughAPI({firstName: 'Kylian', lastName: 'Mbappe', email: ['mbappe@psg.com'], phone: ['573045853049'], token: authToken.token});
@@ -22,7 +27,7 @@ describe('Fetch Contacts UI Tests with APIs - ', () => {
 
 
     it('Should fetch all 3 contacts -', async () => {
-        await expect(ContactsPage.page1Button).toBeDisplayed();
+        await ContactsPage.page1Button.waitForDisplayed({timeout: 20000})
         await expect(ContactsPage.page2Button).not.toBeDisplayed();
 
         await expect(ContactsPage.contact1Card).toBeDisplayed();

--- a/test/specs/ui-api-test.js
+++ b/test/specs/ui-api-test.js
@@ -22,7 +22,7 @@ describe('Fetch Contacts UI Tests with APIs - ', () => {
         await APIClient.createContactThroughAPI({firstName: 'Kylian', lastName: 'Mbappe', email: ['mbappe@psg.com'], phone: ['573045853049'], token: authToken.token});
         
         await LoginPage.login('ihsaan@addressbooktest.com', 'pass12345');
-        $('//nz-page-header-title[contains(text(), "Ihsaan Muhiyadheen")]').waitForDisplayed({timeout: 30000, timeoutMsg: 'Timed-out waiting for contacts page to appear after login.'})
+        await $('//nz-page-header-title[contains(text(), "Ihsaan Muhiyadheen")]').waitForDisplayed({timeout: 30000, timeoutMsg: 'Timed-out waiting for contacts page to appear after login.'})
     });
 
 

--- a/test/specs/ui-test.js
+++ b/test/specs/ui-test.js
@@ -7,12 +7,10 @@ describe('Fetch Contacts UI only Tests - ', () => {
         await LoginPage.open();
         await LoginPage.login('ihsaan@addressbooktest.com', 'pass12345');
 
-        $('//nz-page-header-title[contains(text(), "Ihsaan Muhiyadheen")]').waitForDisplayed({timeout: 30000, timeoutMsg: 'Timed-out waiting for contacts page to appear after login.'})
+        await $('//nz-page-header-title[contains(text(), "Ihsaan Muhiyadheen")]').waitForDisplayed({timeout: 30000, timeoutMsg: 'Timed-out waiting for contacts page to appear after login.'})
 
-        //Delete the existing 3 contacts
-       await ContactsPage.deleteFirstContact();
-       await ContactsPage.deleteFirstContact();
-       await ContactsPage.deleteFirstContact();
+        //Delete all the contacts present
+        await ContactsPage.deleteAllContacts();
 
         //Create 3 contacts
         await ContactsPage.createContact("Lionel", "Messi", "8327324597", "messi@psg.com");

--- a/test/specs/ui-test.js
+++ b/test/specs/ui-test.js
@@ -9,14 +9,19 @@ describe('Fetch Contacts UI only Tests - ', () => {
 
         $('//nz-page-header-title[contains(text(), "Ihsaan Muhiyadheen")]').waitForDisplayed({timeout: 30000, timeoutMsg: 'Timed-out waiting for contacts page to appear after login.'})
 
+        //Delete the existing 3 contacts
+       await ContactsPage.deleteFirstContact();
+       await ContactsPage.deleteFirstContact();
+       await ContactsPage.deleteFirstContact();
+
         //Create 3 contacts
-        await ContactsPage.createContact("Lionel", "Messi", "832732459723", "messi@psg.com");
+        await ContactsPage.createContact("Lionel", "Messi", "8327324597", "messi@psg.com");
         await ContactsPage.createContact("Cristiano", "Ronaldo", "9829348534", "ronaldo@alnassrfc.com");
-        await ContactsPage.createContact("Kylian", "Mbappe", "573045853049", "mbappe@psg.com");
+        await ContactsPage.createContact("Kylian", "Mbappe", "5730458530", "mbappe@psg.com");
     });
 
     it('Should fetch all 3 contacts -', async () => {
-        await expect(ContactsPage.page1Button).toBeDisplayed();
+        await ContactsPage.page1Button.waitForDisplayed({timeout: 20000})
         await expect(ContactsPage.page2Button).not.toBeDisplayed();
 
         await expect(ContactsPage.contact1Card).toBeDisplayed();

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -23,9 +23,9 @@ export const config = {
     // will be called from there.
     //
     specs: [
-        // './test/specs/**/*.js'
-        // './test/specs/ui-api-test.js'
-        './test/specs/ui-test.js'
+        './test/specs/**/*.js'
+        // './test/specs/ui-api-test.js' 
+        // './test/specs/ui-test.js'
     ],
     // Patterns to exclude.
     exclude: [


### PR DESCRIPTION
- Every time we run the test cases, the current state of the system cannot be determined. This makes it difficult to guess the number of contacts when we start the test run.
- As a result, a process that I have been following is to wipe out all the contacts in the account and start afresh.
- In this PR, I have added steps for the same in both spec files' `before()` block.